### PR TITLE
Use dissimilar for diffs instead of difference

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "expect-test"
-version = "1.0.2"
+version = "1.1.0"
 description = "Minimalistic snapshot testing library"
 keywords = ["snapshot", "testing", "expect"]
 categories = ["development-tools::testing"]
@@ -13,4 +13,4 @@ exclude = [".github/", "bors.toml", "rustfmt.toml"]
 
 [dependencies]
 once_cell = "1"
-difference = "2"
+dissimilar = "1"


### PR DESCRIPTION
As discussed with @matklad in https://github.com/rust-analyzer/rust-analyzer/pull/7106.

Before:
![expect-test-screen-difference](https://user-images.githubusercontent.com/22473248/103417757-4d573e80-4b8c-11eb-8f5e-3f0597743279.png)

After:
![expect-test-screen](https://user-images.githubusercontent.com/22473248/103417761-4defd500-4b8c-11eb-9497-33d65ae60e07.png)

Used background instead of foreground colours because I think the diff boundaries are clearer, but I'm not married to that change ;)