### PR TITLE
Respect user provided absolute path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "expect-test"
-version = "1.2.0-pre.1"
+version = "1.2.1"
 description = "Minimalistic snapshot testing library"
 keywords = ["snapshot", "testing", "expect"]
 categories = ["development-tools::testing"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,8 +302,12 @@ impl ExpectFile {
         fs::write(self.abs_path(), contents).unwrap()
     }
     fn abs_path(&self) -> PathBuf {
-        let dir = Path::new(self.position).parent().unwrap();
-        WORKSPACE_ROOT.join(dir).join(&self.path)
+        if self.path.is_absolute() {
+            self.path.to_owned()
+        } else {
+            let dir = Path::new(self.position).parent().unwrap();
+            WORKSPACE_ROOT.join(dir).join(&self.path)
+        }
     }
 }
 
@@ -475,7 +479,8 @@ fn format_patch(desired_indent: Option<usize>, patch: &str) -> String {
 }
 
 static WORKSPACE_ROOT: Lazy<PathBuf> = Lazy::new(|| {
-    let my_manifest = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let my_manifest = env::var("CARGO_MANIFEST_DIR")
+        .expect("No CARGO_MANIFEST_DIR available. Consider using absolute path.");
     // Heuristic, see https://github.com/rust-lang/cargo/issues/3946
     Path::new(&my_manifest)
         .ancestors()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -507,7 +507,7 @@ fn to_abs_ws_path(path: &Path) -> PathBuf {
             }
         };
 
-        workspace_root.join(path).to_owned()
+        workspace_root.join(path).canonicalize().unwrap()
     }
 }
 


### PR DESCRIPTION
When the environment variable CARGO_MANIFEST_DIR is not present as is the default when opening a workspace project in vs code and running the tests. `expect-test` panics.

The problem can be reproduced with this minimal project https://github.com/mvtec-bergdolll/expect-test-repro-proj/tree/main. Open it in vs code and run the integration tests. They panic. However running them from the shell does not panic. That's unfortunate.

As user trying to debug this I was confused why it failed even when providing an absolute path.

This change includes:
- Do not query CARGO_MANIFEST_DIR if the user already provided an absolute path when calculating an absolute path
- Better error message when CARGO_MANIFEST_DIR is not present

I'm not sure how to easily test this so I've not added automated testing.