### PR TITLE
Handle some cases where "]]" appears in a string literal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ exclude = [".github/", "bors.toml", "rustfmt.toml"]
 [dependencies]
 once_cell = "1"
 dissimilar = "1"
+regex = "1.5.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,6 +288,12 @@ impl Expect {
 fn locate_end(expect_invocation_to_eof: &str) -> Option<usize> {
     static TRAILER: Lazy<Regex> = Lazy::new(|| Regex::new(r##""#*(\s*]])"##).unwrap());
 
+    // First, check for `expect![[]]` (no literal).
+    let mut chars = expect_invocation_to_eof.chars().skip_while(|c| c.is_whitespace());
+    if (']', ']') == (chars.next()?, chars.next()?) {
+        return Some(0);
+    }
+
     let trailer = TRAILER.captures(expect_invocation_to_eof)?;
     let literal_end = trailer.get(0).unwrap().end() - trailer[1].len();
     Some(literal_end)
@@ -693,5 +699,8 @@ line1
             // [["\"]]"]],
             // [[r#""]]"#]],
         );
+
+        // Check `expect![[  ]]` as well.
+        assert_eq!(locate_end(" ]]"), Some(0));
     }
 }


### PR DESCRIPTION
A partial fix for #20.