### PR TITLE
Allow users to rebind `expect!`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,15 +39,12 @@
 //! # Guide
 //!
 //! `expect!` returns an instance of `Expect` struct, which holds position
-//! information and a string literal. Importing `expect!` under a different
-//! name is supported; `UPDATE_EXPECT` will continue to work.
-//!
-//! Use `Expect::assert_eq` for string comparison. Use
-//! `Expect::assert_debug_eq` for verbose debug comparison. Note that leading
-//! indentation is automatically removed.
+//! information and a string literal. Use `Expect::assert_eq` for string
+//! comparison. Use `Expect::assert_debug_eq` for verbose debug comparison. Note
+//! that leading indentation is automatically removed.
 //!
 //! ```
-//! use expect_test::expect as ex; // Note the renaming
+//! use expect_test::expect;
 //!
 //! #[derive(Debug)]
 //! struct Foo {
@@ -55,7 +52,7 @@
 //! }
 //!
 //! let actual = Foo { value: 92 };
-//! let expected = ex![["
+//! let expected = expect![["
 //!     Foo {
 //!         value: 92,
 //!     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,19 +32,22 @@
 //! This becomes very useful when you have a lot of tests with verbose and
 //! potentially changing expected output.
 //!
-//! Under the hood, `expect!` macro uses `file!` and `line!` to record source
-//! position at compile time. At runtime, this position is used to patch the
-//! file in-place, if `UPDATE_EXPECT` is set.
+//! Under the hood, the `expect!` macro uses `file!`, `line!` and `column!` to
+//! record source position at compile time. At runtime, this position is used
+//! to patch the file in-place, if `UPDATE_EXPECT` is set.
 //!
 //! # Guide
 //!
 //! `expect!` returns an instance of `Expect` struct, which holds position
-//! information and a string literal. Use `Expect::assert_eq` for string
-//! comparison. Use `Expect::assert_debug_eq` for verbose debug comparison. Note
-//! that leading indentation is automatically removed.
+//! information and a string literal. Importing `expect!` under a different
+//! name is supported; `UPDATE_EXPECT` will continue to work.
+//!
+//! Use `Expect::assert_eq` for string comparison. Use
+//! `Expect::assert_debug_eq` for verbose debug comparison. Note that leading
+//! indentation is automatically removed.
 //!
 //! ```
-//! use expect_test::expect;
+//! use expect_test::expect as ex; // Note the renaming
 //!
 //! #[derive(Debug)]
 //! struct Foo {
@@ -52,7 +55,7 @@
 //! }
 //!
 //! let actual = Foo { value: 92 };
-//! let expected = expect![["
+//! let expected = ex![["
 //!     Foo {
 //!         value: 92,
 //!     }


### PR DESCRIPTION
Currently, `expect-test` checks for the string `expect![[` when updating test cases. As a result, setting `UPDATE_EXPECT=1` will cause a panic if `expect` is imported under a different name.

We have the `column` of the macro invocation for each `Expect`. Use that as a starting point instead.