### PR TITLE
Support single delimiter version of `expect![]`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //! use expect_test::expect;
 //!
 //! let actual = 2 + 2;
-//! let expected = expect![["5"]];
+//! let expected = expect!["5"]; // or expect![["5"]]
 //! expected.assert_eq(&actual.to_string())
 //! ```
 //!
@@ -25,7 +25,7 @@
 //! ```no_run
 //! # use expect_test::expect;
 //! let actual = 2 + 2;
-//! let expected = expect![["4"]];
+//! let expected = expect!["4"];
 //! expected.assert_eq(&actual.to_string())
 //! ```
 //!
@@ -152,7 +152,7 @@ use std::{
 use once_cell::sync::{Lazy, OnceCell};
 
 const HELP: &str = "
-You can update all `expect![[]]` tests by running:
+You can update all `expect!` tests by running:
 
     env UPDATE_EXPECT=1 cargo test
 
@@ -170,6 +170,7 @@ fn update_expect() -> bool {
 /// expect![["
 ///     Foo { value: 92 }
 /// "]];
+/// expect![r#"{"Foo": 92}"#];
 /// ```
 ///
 /// Leading indentation is stripped.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -728,24 +728,24 @@ mod tests {
     fn test_format_patch() {
         let patch = format_patch(None, "hello\nworld\n");
         expect![[r##"
-            r#"
+            [r#"
             hello
             world
-            "#"##]]
+            "#]"##]]
         .assert_eq(&patch);
 
         let patch = format_patch(None, r"hello\tworld");
-        expect![[r##"r#"hello\tworld"#"##]].assert_eq(&patch);
+        expect![[r##"[r#"hello\tworld"#]"##]].assert_eq(&patch);
 
         let patch = format_patch(None, "{\"foo\": 42}");
-        expect![[r##"r#"{"foo": 42}"#"##]].assert_eq(&patch);
+        expect![[r##"[r#"{"foo": 42}"#]"##]].assert_eq(&patch);
 
         let patch = format_patch(Some(0), "hello\nworld\n");
         expect![[r##"
-            r#"
+            [r#"
                 hello
                 world
-            "#"##]]
+            "#]"##]]
         .assert_eq(&patch);
 
         let patch = format_patch(Some(4), "single line");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -606,6 +606,9 @@ fn format_patch(desired_indent: Option<usize>, patch: &str) -> String {
     let is_multiline = patch.contains('\n');
 
     let mut buf = String::new();
+    if matches!(lit_kind, StrLitKind::Raw(_)) {
+        buf.push('[');
+    }
     lit_kind.write_start(&mut buf).unwrap();
     if is_multiline {
         buf.push('\n');
@@ -627,6 +630,9 @@ fn format_patch(desired_indent: Option<usize>, patch: &str) -> String {
         }
     }
     lit_kind.write_end(&mut buf).unwrap();
+    if matches!(lit_kind, StrLitKind::Raw(_)) {
+        buf.push(']');
+    }
     buf
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -725,6 +725,11 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_trivial_assert() {
+        expect!["5"].assert_eq("5");
+    }
+
+    #[test]
     fn test_format_patch() {
         let patch = format_patch(None, "hello\nworld\n");
         expect![[r##"


### PR DESCRIPTION
Pairs of braces are no longer necessary that we parse string literals. Allow users to omit the inner `[]`.

This represents a significant change to the public API, and you might have other tooling that depends on the paired braces, so I understand if you don't want it upstream. I think it reads a bit nicer, though.

Depends on #26 (although it could be separated), and is similarly lacking in integration tests for now.