### PR TITLE
Use the minimal number of escapes when updating tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -721,7 +721,7 @@ mod tests {
         .assert_eq(&patch);
 
         let patch = format_patch(Some(4), "single line");
-        expect![[r##"r#"single line"#"##]].assert_eq(&patch);
+        expect![[r#""single line""#]].assert_eq(&patch);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -712,6 +712,12 @@ mod tests {
             "#"##]]
         .assert_eq(&patch);
 
+        let patch = format_patch(None, r"hello\tworld");
+        expect![[r##"r#"hello\tworld"#"##]].assert_eq(&patch);
+
+        let patch = format_patch(None, "{\"foo\": 42}");
+        expect![[r##"r#"{"foo": 42}"#"##]].assert_eq(&patch);
+
         let patch = format_patch(Some(0), "hello\nworld\n");
         expect![[r##"
             r#"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,6 +238,40 @@ impl fmt::Display for Position {
     }
 }
 
+#[derive(Clone, Copy)]
+enum StrLitKind {
+    Normal,
+    Raw(usize),
+}
+
+impl StrLitKind {
+    fn write_start(self, w: &mut impl std::fmt::Write) -> std::fmt::Result {
+        match self {
+            Self::Normal => write!(w, "\""),
+            Self::Raw(n) => {
+                write!(w, "r")?;
+                for _ in 0..n {
+                    write!(w, "#")?;
+                }
+                write!(w, "\"")
+            }
+        }
+    }
+
+    fn write_end(self, w: &mut impl std::fmt::Write) -> std::fmt::Result {
+        match self {
+            Self::Normal => write!(w, "\""),
+            Self::Raw(n) => {
+                write!(w, "\"")?;
+                for _ in 0..n {
+                    write!(w, "#")?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
 impl Expect {
     /// Checks if this expect is equal to `actual`.
     pub fn assert_eq(&self, actual: &str) {
@@ -324,11 +358,6 @@ fn locate_end(lit_to_eof: &str) -> Option<usize> {
 /// (either a quote or a hash).
 fn find_str_lit_len(str_lit_to_eof: &str) -> Option<usize> {
     use StrLitKind::*;
-    #[derive(Clone, Copy)]
-    enum StrLitKind {
-        Normal,
-        Raw(usize),
-    }
 
     fn try_find_n_hashes(
         s: &mut impl Iterator<Item = char>,


### PR DESCRIPTION
Currently, `expect-test` uses a raw string with at least one hash when blessing tests. This is a bit verbose for single-line output that doesn't contain any quotes or escaped characters.

This PR parses each patch to find the simplest string literal that can represent it losslessly, and uses that instead. For now, multiline patches continue to use raw string literals (with the minimum number of hashes), although I think they could use regular ones.