### PR TITLE
Add data getter to `Expect`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,19 @@
+# 1.3.0
+
+* Add `data()` getter to Expect ([#31])
+* Support single delimiter version of `expect![]` ([#27])
+* Allow users to rebind `expect!` ([#26])
+
 # 1.2.2
 
+* Parse string literals to find their length ([#23])
 * Do not use `fs::canonicalize`.
 
 # 1.2.1
 
 * No changelog until this point :-(
+
+[#31]: https://github.com/rust-analyzer/expect-test/pull/31
+[#27]: https://github.com/rust-analyzer/expect-test/pull/27
+[#26]: https://github.com/rust-analyzer/expect-test/pull/26
+[#23]: https://github.com/rust-analyzer/expect-test/pull/23

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "expect-test"
-version = "1.2.2"
+version = "1.3.0"
 description = "Minimalistic snapshot testing library"
 keywords = ["snapshot", "testing", "expect"]
 categories = ["development-tools::testing"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,6 +294,11 @@ impl Expect {
         self.indent = yes;
     }
 
+    /// Returns the content of this expect.
+    pub fn data(&self) -> &str {
+        self.data
+    }
+
     fn trimmed(&self) -> String {
         if !self.data.contains('\n') {
             return self.data.to_string();


### PR DESCRIPTION
Closes https://github.com/rust-analyzer/expect-test/issues/14.

The getter doesn't return an `&str` with `'static` lifetime intentionally, because it makes the API more conservative, and gives more freedom to the implementation. 