### PR TITLE
Use foreground colors instead of background colors to highlight diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.4.1
+
+* Use foreground colors instead of background colors to highlight diffs ([#36])
+
 # 1.4.0
 
 * Prefer `CARGO_WORKSPACE_DIR` if set, use heuristic as fallback to find cargo workspace ([#34])
@@ -17,6 +21,7 @@
 
 * No changelog until this point :-(
 
+[#36]: https://github.com/rust-analyzer/expect-test/pull/36
 [#34]: https://github.com/rust-analyzer/expect-test/pull/34
 [#31]: https://github.com/rust-analyzer/expect-test/pull/31
 [#27]: https://github.com/rust-analyzer/expect-test/pull/27

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "expect-test"
-version = "1.4.0"
+version = "1.4.1"
 description = "Minimalistic snapshot testing library"
 keywords = ["snapshot", "testing", "expect"]
 categories = ["development-tools::testing"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -719,8 +719,8 @@ fn format_chunks(chunks: Vec<dissimilar::Chunk>) -> String {
     for chunk in chunks {
         let formatted = match chunk {
             dissimilar::Chunk::Equal(text) => text.into(),
-            dissimilar::Chunk::Delete(text) => format!("\x1b[41m{}\x1b[0m", text),
-            dissimilar::Chunk::Insert(text) => format!("\x1b[42m{}\x1b[0m", text),
+            dissimilar::Chunk::Delete(text) => format!("\x1b[31m{}\x1b[0m", text),
+            dissimilar::Chunk::Insert(text) => format!("\x1b[32m{}\x1b[0m", text),
         };
         buf.push_str(&formatted);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -719,8 +719,8 @@ fn format_chunks(chunks: Vec<dissimilar::Chunk>) -> String {
     for chunk in chunks {
         let formatted = match chunk {
             dissimilar::Chunk::Equal(text) => text.into(),
-            dissimilar::Chunk::Delete(text) => format!("\x1b[31m{}\x1b[0m", text),
-            dissimilar::Chunk::Insert(text) => format!("\x1b[32m{}\x1b[0m", text),
+            dissimilar::Chunk::Delete(text) => format!("\x1b[4m\x1b[31m{}\x1b[0m", text),
+            dissimilar::Chunk::Insert(text) => format!("\x1b[4m\x1b[32m{}\x1b[0m", text),
         };
         buf.push_str(&formatted);
     }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2,7 +2,7 @@ use std::env;
 
 use xaction::{cargo_toml, cmd, git, push_rustup_toolchain, section, Result};
 
-const MSRV: &str = "1.45.0";
+const MSRV: &str = "1.56.0";
 
 fn main() {
     if let Err(err) = try_main() {


### PR DESCRIPTION
I think foreground colors are more "standard", and the background colors make things unreadable in my color scheme.

Before:
<img width="721" alt="Screenshot 2023-02-06 at 2 33 31 PM" src="https://user-images.githubusercontent.com/2042019/217068209-104e52c4-49d1-441a-942a-97a9d09dad93.png">

After:
<img width="711" alt="Screenshot 2023-02-06 at 2 38 40 PM" src="https://user-images.githubusercontent.com/2042019/217068362-ecda96a1-e225-4c95-95cb-94469a3d87cb.png">
