### PR TITLE
Make the `data` from an `ExpectFile` accessible

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -434,7 +434,7 @@ fn find_str_lit_len(str_lit_to_eof: &str) -> Option<usize> {
 impl ExpectFile {
     /// Checks if file contents is equal to `actual`.
     pub fn assert_eq(&self, actual: &str) {
-        let expected = self.read();
+        let expected = self.data();
         if actual == expected {
             return;
         }
@@ -445,7 +445,8 @@ impl ExpectFile {
         let actual = format!("{:#?}\n", actual);
         self.assert_eq(&actual)
     }
-    fn read(&self) -> String {
+    /// Returns the content of this expect.
+    pub fn data(&self) -> String {
         fs::read_to_string(self.abs_path()).unwrap_or_default().replace("\r\n", "\n")
     }
     fn write(&self, contents: &str) {


### PR DESCRIPTION
I'm using `expect-test` in probably a weird semi-abusive way.

I'm writing tests for a network protocol. My tests run in one of three modes:

1. **Record**: a normal `expect-test` flow with `UPDATE_EXPECT=1`; records both the inputs and outputs to the live system
1. **Check**: a normal `expect-test` flow with `UPDATE_EXPECT=0`; asserts on both the inputs and outputs and fails if they've changed
1. **Replay**: uses `.data` to supply the inputs and asserts only on the outputs from the implementation.

It would be helpful if `ExpectFile` let me see into underlying `data` as easily as `Expect` does.