### PR TITLE
doc: update the recommended placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.5.1
+
+* Documentation improvements
+
 # 1.5.0
 
 * Make the `data` from an `ExpectFile` accessible ([#43])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "expect-test"
-version = "1.5.0"
+version = "1.5.1"
 description = "Minimalistic snapshot testing library"
 keywords = ["snapshot", "testing", "expect"]
 categories = ["development-tools::testing"]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Updating a failing test:
 
 https://user-images.githubusercontent.com/1711539/120119633-73b3f100-c1a1-11eb-91be-4c61a23e7060.mp4
 
-Adding a new test:
+Adding a new test: Just leave a blank `expect![[""]]` and update it:
 
 ![expect-fresh](https://user-images.githubusercontent.com/1711539/85926961-306f4500-b8a3-11ea-9369-f2373e327a3f.gif)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@
 //! # fn check(_: i32, _: Expect) {}
 //! #[test]
 //! fn test_division() {
-//!     check(92 / 2, expect![[]])
+//!     check(92 / 2, expect![[""]])
 //! }
 //! ```
 //!


### PR DESCRIPTION
Currently recommended `expect![[]]` is broken #37, and #38 is blocked for long time, so maybe we can update the recommendation to a safer option instead.