### PR TITLE
Use `std::sync::LazyLock` instead of `once_cell::Lazy`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,12 +16,35 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+          toolchain: stable
+          profile: minimal
+    - name: Test Rust Stable
+      run: cargo test
+      env:
+        RUST_TOOLCHAIN: stable
 
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+          toolchain: 1.60
+          profile: minimal
+    - name: Build Rust MSRV (1.60)
+      run: cargo build
+
+  publish:
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0 # fetch tags for publish
-
-    - run: cargo run -p xtask -- ci
+    - name: Publish
+      run: cargo run -p xtask -- ci
       env:
         CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,10 +146,10 @@ use std::{
     ops::Range,
     panic,
     path::{Path, PathBuf},
-    sync::Mutex,
+    sync::{LazyLock, Mutex},
 };
 
-use once_cell::sync::{Lazy, OnceCell};
+use once_cell::sync::OnceCell;
 
 const HELP: &str = "
 You can update all `expect!` tests by running:
@@ -467,7 +467,7 @@ struct Runtime {
     help_printed: bool,
     per_file: HashMap<&'static str, FileRuntime>,
 }
-static RT: Lazy<Mutex<Runtime>> = Lazy::new(Default::default);
+static RT: LazyLock<Mutex<Runtime>> = LazyLock::new(Default::default);
 
 impl Runtime {
     fn fail_expect(expect: &Expect, expected: &str, actual: &str) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -694,7 +694,7 @@ fn trim_indent(mut text: &str) -> String {
         .collect()
 }
 
-fn lines_with_ends(text: &str) -> LinesWithEnds {
+fn lines_with_ends(text: &str) -> LinesWithEnds<'_> {
     LinesWithEnds { text }
 }
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-xaction = "0.2.1"
+xshell = "0.2.7"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,8 +1,9 @@
-use std::env;
+use std::{env, fs, path::PathBuf};
 
-use xaction::{cargo_toml, cmd, git, push_rustup_toolchain, section, Result};
+use xshell::{cmd, Shell};
 
-const MSRV: &str = "1.60.0";
+pub type Error = Box<dyn std::error::Error>;
+pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 fn main() {
     if let Err(err) = try_main() {
@@ -21,34 +22,53 @@ fn try_main() -> Result<()> {
         }
     }
 
-    let cargo_toml = cargo_toml()?;
+    let sh = &Shell::new().unwrap();
 
-    {
-        let _s = section("TEST_STABLE");
-        let _t = push_rustup_toolchain("stable");
-        cmd!("cargo test").run()?;
-    }
-
-    {
-        let _s = section("TEST_MSRV");
-        let _t = push_rustup_toolchain(MSRV);
-        cmd!("cargo build").run()?;
-    }
-
-    let version = cargo_toml.version()?;
+    let cargo_toml = cargo_toml(sh)?;
+    let version = cargo_toml.get("version")?;
     let tag = format!("v{}", version);
 
     let dry_run =
-        env::var("CI").is_err() || git::has_tag(&tag)? || git::current_branch()? != "master";
-    xaction::set_dry_run(dry_run);
+        env::var("CI").is_err() || git::has_tag(sh, &tag)? || git::current_branch(sh)? != "master";
 
-    {
-        let _s = section("PUBLISH");
-        cargo_toml.publish()?;
-        git::tag(&tag)?;
-        git::push_tags()?;
+    let token = env::var("CRATES_IO_TOKEN").unwrap_or("no token".to_string());
+    let dry_run_flag = dry_run.then_some("--dry-run");
+    cmd!(sh, "cargo publish --token {token} {dry_run_flag...}").run()?;
+
+    if !dry_run {
+        cmd!(sh, "git tag {tag}").run()?;
+        cmd!(sh, "git push --tags").run()?;
     }
+
     Ok(())
+}
+
+pub fn cargo_toml(sh: &Shell) -> Result<CargoToml> {
+    let cwd = sh.current_dir();
+    let path = cwd.join("Cargo.toml");
+    let contents = fs::read_to_string(&path)?;
+    Ok(CargoToml { path, contents })
+}
+
+pub struct CargoToml {
+    path: PathBuf,
+    contents: String,
+}
+
+impl CargoToml {
+    fn get(&self, field: &str) -> Result<&str> {
+        for line in self.contents.lines() {
+            let words = line.split_ascii_whitespace().collect::<Vec<_>>();
+            match words.as_slice() {
+                [n, "=", v, ..] if n.trim() == field => {
+                    assert!(v.starts_with('"') && v.ends_with('"'));
+                    return Ok(&v[1..v.len() - 1]);
+                }
+                _ => (),
+            }
+        }
+        Err(format!("can't find `{}` in {}", field, self.path.display()))?
+    }
 }
 
 fn print_usage() {
@@ -60,4 +80,25 @@ SUBCOMMANDS:
     ci
 "
     )
+}
+
+mod git {
+    use crate::Result;
+    use xshell::{cmd, Shell};
+
+    pub(crate) fn current_branch(sh: &Shell) -> Result<String> {
+        let res = cmd!(sh, "git branch --show-current").read()?;
+        Ok(res)
+    }
+
+    pub(crate) fn has_tag(sh: &Shell, tag: &str) -> Result<bool> {
+        let res = tag_list(sh)?.iter().any(|it| it == tag);
+        Ok(res)
+    }
+
+    pub fn tag_list(sh: &Shell) -> Result<Vec<String>> {
+        let tags = cmd!(sh, "git tag --list").read()?;
+        let res = tags.lines().map(|it| it.trim().to_string()).collect();
+        Ok(res)
+    }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2,8 +2,8 @@ use std::{env, fs, path::PathBuf};
 
 use xshell::{cmd, Shell};
 
-pub type Error = Box<dyn std::error::Error>;
-pub type Result<T, E = Error> = std::result::Result<T, E>;
+type Error = Box<dyn std::error::Error>;
+type Result<T, E = Error> = std::result::Result<T, E>;
 
 fn main() {
     if let Err(err) = try_main() {
@@ -22,14 +22,14 @@ fn try_main() -> Result<()> {
         }
     }
 
-    let sh = &Shell::new().unwrap();
+    let sh = Shell::new()?;
 
-    let cargo_toml = cargo_toml(sh)?;
+    let cargo_toml = cargo_toml(&sh)?;
     let version = cargo_toml.get("version")?;
     let tag = format!("v{}", version);
 
     let dry_run =
-        env::var("CI").is_err() || git::has_tag(sh, &tag)? || git::current_branch(sh)? != "master";
+        env::var("CI").is_err() || git::has_tag(&sh, &tag)? || git::current_branch(&sh)? != "master";
 
     let token = env::var("CRATES_IO_TOKEN").unwrap_or("no token".to_string());
     let dry_run_flag = dry_run.then_some("--dry-run");
@@ -96,7 +96,7 @@ mod git {
         Ok(res)
     }
 
-    pub fn tag_list(sh: &Shell) -> Result<Vec<String>> {
+    fn tag_list(sh: &Shell) -> Result<Vec<String>> {
         let tags = cmd!(sh, "git tag --list").read()?;
         let res = tags.lines().map(|it| it.trim().to_string()).collect();
         Ok(res)

--- a/xtask/tests/tidy.rs
+++ b/xtask/tests/tidy.rs
@@ -1,6 +1,8 @@
-use xaction::cmd;
+use xshell::{cmd, Shell};
 
 #[test]
 fn test_formatting() {
-    cmd!("cargo fmt --all -- --check").run().unwrap()
+    let sh = &Shell::new().unwrap();
+
+    cmd!(sh, "cargo fmt --all -- --check").run().unwrap()
 }

--- a/xtask/tests/tidy.rs
+++ b/xtask/tests/tidy.rs
@@ -2,7 +2,7 @@ use xshell::{cmd, Shell};
 
 #[test]
 fn test_formatting() {
-    let sh = &Shell::new().unwrap();
+    let sh = Shell::new().unwrap();
 
     cmd!(sh, "cargo fmt --all -- --check").run().unwrap()
 }


### PR DESCRIPTION
Exactly what is says on the tin.

We can't replace `once_cell::OnceCell` with `std::cell::OnceCell` yet because `expect-test` uses the try api (https://github.com/rust-lang/rust/issues/109737).